### PR TITLE
Refactor about us page

### DIFF
--- a/src/components/about/Feature.jsx
+++ b/src/components/about/Feature.jsx
@@ -1,0 +1,50 @@
+import React, { useRef } from "react";
+import { useSelector } from "react-redux";
+import { Typography, Box, Card, CardMedia, CardContent } from "@mui/material";
+import CardComponent from "../common/Card";
+import useFetchCards from "../../hooks/useFetchCards";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+// import Card from "../common/Card";
+
+const Feature = ({ data }) => {
+  const { baseUrl } = useSelector((state) => state.content);
+  const featureSection = data.included?.find(
+    (item) => item.type === "paragraph--feature_section"
+  );
+  const featureCards = useFetchCards(featureSection, "field_feature_list");
+  const sliderRef = useRef(null);
+
+  if (!featureSection) return null;
+
+  return (
+    <Box className="feature-container">
+      <Typography variant="h4" className="text-center p-2" gutterBottom>
+        {featureSection.attributes.field_title}
+      </Typography>
+      {featureCards.map((card, index) => (
+        <Box key={index} className="slider-item">
+          {/* <Card
+            imageUrl={card.imageUrl}
+            title={card.attributes.field_card_title}
+            description={card.attributes.field_card_description}
+            ctaButton={card.attributes.field_card_cta_button}
+          /> */}
+          <Card>
+            <CardMedia title="" image={card.imageUrl} />
+            <CardContent>
+                <Typography variant="h5" gutterBottom>
+                    {card.attributes.field_card_title}
+                </Typography>
+                <Typography variant="body1" gutterBottom>
+                    {card.attributes.field_card_description}
+                </Typography>
+            </CardContent>
+          </Card>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export default Feature;

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { fetchContentData } from "../redux/contentSlice";
 import { Container, Box, Typography, Button } from "@mui/material";
 import Hero from "../components/common/Hero"; // Import the reusable component
-import Feature from "../components/homepage/components/Feature";
+import Feature from "../components/about/Feature";
 import ConnectCard from "../components/servicespage/components/ConnectCard";
 import Loading from "../components/common/Loading";
 import Error from "../components/common/Error";
@@ -81,7 +81,7 @@ const About = () => {
     <Container disableGutters maxWidth="xl">
       {heroSection && <Hero data={{ included: [heroSection] }} />}
       {paragraphCard && (
-        <Box sx={{ margin: "2rem 0", alignItems: "center", display:"flex", flexDirection:"column-reverse" }}>
+        <Box sx={{ margin: "2rem 0", alignItems: "center", display:"flex", flexDirection:"column" }}>
           {paragraphCard.imageUrl && (
             <Box
               component="img"


### PR DESCRIPTION
This PR #49 includes significant updates to the `Feature` component in the `about` section, along with minor adjustments to the `About` page. The most important changes include the creation of a new `Feature` component, updating imports, and modifying the layout of the `About` page.

New `Feature` component:

* [`src/components/about/Feature.jsx`](diffhunk://#diff-99ee2872ee78e4363000ca1569536822ac903c6a8e33444856efe5b45a90fe75R1-R50): Created a new `Feature` component that fetches and displays feature cards using the `useFetchCards` hook and `useSelector` from `react-redux`. This component uses Material-UI components for styling and layout.

Updates to imports:

* [`src/pages/About.jsx`](diffhunk://#diff-561d913b8bc6b39240c795c268c564deb088242be24f0102472dc9a7977468d8L6-R6): Updated the import path for the `Feature` component to reflect its new location in the `about` directory.

Layout modifications:

* [`src/pages/About.jsx`](diffhunk://#diff-561d913b8bc6b39240c795c268c564deb088242be24f0102472dc9a7977468d8L84-R84): Adjusted the flex direction of the `Box` component wrapping the `paragraphCard` to display its children in a column instead of a column-reverse layout.